### PR TITLE
Login Logout

### DIFF
--- a/amazon_manipulator.rb
+++ b/amazon_manipulator.rb
@@ -14,8 +14,8 @@ class AmazonManipulator
     @account = read(account_file) # <5>
   end
 
-  def run
-    @driver.get 'https://www.amazon.co.jp/'
+  def login #<1>
+    @driver.get BASE_URL
     element = @driver.find_element(:id, 'nav-link-accountList')
     puts element.text
     element.click
@@ -30,8 +30,24 @@ class AmazonManipulator
     element = @driver.find_element(:id, 'signInSubmit')
     element.click
     @wait.until { @driver.find_element(:id, 'nav-link-accountList').displayed? }
-    sleep 3
-    @driver.quit
+  end
+
+  def logout #<2>
+    @wait.until { @driver.find_element(:id, 'nav-link-accountList').displayed? }
+    element = @driver.find_element(:id, 'nav-link-accountList' )
+    @driver.action.move_to(element).perform #<3>
+    @wait.until {@driver.find_element(:id, 'nav-item-signout').displayed? }
+    element = @driver.find_element(:id, 'nav-item-signout') #<4>
+    element.click #<5>
+    @wait.until { @driver.find_element(:id, 'ap_email').displayed? } #<6>
+  end
+
+  def run #<7>
+    login
+    sleep 3 #<8>
+    logout
+    sleep 3 #<9>
+    @driver.quit #<10>
   end
 end
 


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/ASONE0923/amazon_manipulator/commit/1cb49aa50133d7c205119cbfe3b9784926a3ca46

## やったこと

* 1.ログインの処理をloginメソッドに分けた。
* 2.終了処理をlogoutメソッドに分けた
* 3.action.move_toメソッドで「アカウント&リスト」へマウスカーソルを移動し、performメソッドでポップアップウィンドウを表示した。
* 4.ポップアップウィンドウの「ログアウト」が表示されるのを待っている。
* 5.ポップアップウィンドウの「ログアウト」をクリックした。
* 6.ログイン画面に戻るのを待つために、メールアドレス入力欄が表示されるのを待っている。
* 7.runメソッドをloginとlogoutを使って書き換えた。
* 8.sleepメソッドをログイン後の処理の代わりにした。
* 9.sleepメソッドで、ログアウト後に表示されるログイン画面をしばらく表示しておく。
* 10.quitメソッドの呼び出しは、AmazonのWebサイトからのログアウト処理とは別なので、logoutからは分離した。
## やらないこと

* 次回コミットにてログインメソッドの修正を図る

## できるようになること（ユーザ目線）

* ruby amazon_manipulator.rb account.json を実行すると、パスワードが入力され、「ログイン」ボタンがクリックされ、ログイン後のトップページが表示される

## できなくなること（ユーザ目線）

* 無し

## 動作確認

*`ruby amazon_manipulator.rb account.json`を実行後問題なく作動。

 [![Image from Gyazo](https://i.gyazo.com/4fa4eb856129eb0afdd3544bd6c0d2a6.png)](https://gyazo.com/4fa4eb856129eb0afdd3544bd6c0d2a6)

## その他

* ターゲット要素にマウスカーソルを移動させる「move_to」。このメソッドを実行することで、(要素のドラッグ状態が維持されたまま)ターゲット要素に対してマウスカーソルを移動させていきます。もし、移動した後にドロップしたい場合は「move_to」の後に「release」メソッドを追加します。最後に「perform」を実行することで、これまでのメソッドをビルドした後、実行していきます。
* 参考:https://www.seleniumqref.com/api/ruby/actions/Ruby_click_and_hold_move_to.html

