### PR TITLE
Fix login

### DIFF
--- a/amazon_manipulator.rb
+++ b/amazon_manipulator.rb
@@ -6,53 +6,82 @@ require_relative './account_info'
 class AmazonManipulator
   include AccountInfo
 
-  BASE_URL = 'https://www.amazon.co.jp/' # <1>
+  BASE_URL = 'https://www.amazon.co.jp/'
 
-  def initialize(account_file) # <2>
-    @driver = Selenium::WebDriver.for :chrome # <3>
-    @wait = Selenium::WebDriver::Wait.new(timeout: 20) # <4>
-    @account = read(account_file) # <5>
+  def initialize(account_file)
+    @driver = Selenium::WebDriver.for :chrome
+    @wait = Selenium::WebDriver::Wait.new(timeout: 20)
+    @account = read(account_file)
   end
 
   def login #<1>
-    @driver.get BASE_URL
-    element = @driver.find_element(:id, 'nav-link-accountList')
-    puts element.text
-    element.click
-    @wait.until { @driver.find_element(:id, 'ap_email').displayed? }
-    element = @driver.find_element(:id, 'ap_email')
-    element.send_keys(@account[:email])
-    element = @driver.find_element(:id, 'continue')
-    element.click
-    @wait.until { @driver.find_element(:id, 'ap_password').displayed? }
-    element = @driver.find_element(:id, 'ap_password')
-    element.send_keys(@account[:password])
-    element = @driver.find_element(:id, 'signInSubmit')
-    element.click
-    @wait.until { @driver.find_element(:id, 'nav-link-accountList').displayed? }
+    open_top_page
+    open_login_page
+    enter_mail_address
+    enter_password
+    wait_for_logged_in
   end
 
   def logout #<2>
-    @wait.until { @driver.find_element(:id, 'nav-link-accountList').displayed? }
-    element = @driver.find_element(:id, 'nav-link-accountList' )
-    @driver.action.move_to(element).perform #<3>
-    @wait.until {@driver.find_element(:id, 'nav-item-signout').displayed? }
-    element = @driver.find_element(:id, 'nav-item-signout') #<4>
-    element.click #<5>
-    @wait.until { @driver.find_element(:id, 'ap_email').displayed? } #<6>
+    open_nav_link_popup
+    wait_for_logged_out
   end
 
-  def run #<7>
+  def run #<3>
     login
-    sleep 3 #<8>
+    sleep 3
     logout
-    sleep 3 #<9>
-    @driver.quit #<10>
+    sleep 3
+    @driver.quit
+  end
+
+  private #<4>
+
+  def wait_and_find_element(how, what) #<5>
+    @wait.until { @driver.find_element(how, what).displayed? }
+    @driver.find_element(how, what)
+  end
+
+  def open_top_page #<6>
+    @driver.get BASE_URL
+    wait_and_find_element(:id, 'navFooter')
+  end
+
+  def open_login_page #<7>
+    element = wait_and_find_element(:id, 'nav-link-accountList')
+    element.click
+  end
+
+  def enter_mail_address #<8>
+    element = wait_and_find_element(:id, 'ap_email')
+    element.send_keys(@account[:email])
+    @driver.find_element(:id, 'continue').click
+  end
+
+  def enter_password #<9>
+    element = wait_and_find_element(:id, 'ap_password')
+    element.send_keys(@account[:password])
+    @driver.find_element(:id, 'signInSubmit').click
+  end
+
+  def wait_for_logged_in #<10>
+    wait_and_find_element(:id, 'nav-link-accountList')
+  end
+
+  def open_nav_link_popup #<11>
+    element = wait_and_find_element(:id, 'nav-link-accountList')
+    @driver.action.move_to(element).perform
+  end
+
+  def wait_for_logged_out #<12>
+    element = wait_and_find_element(:id, 'nav-item-signout')
+    element.click
+    wait_and_find_element(:id, 'ap_email')
   end
 end
 
 if __FILE__ == $PROGRAM_NAME
-  abort 'account file not specified.' unless ARGV.size == 1 # <6>
-  app = AmazonManipulator.new(ARGV[0]) # <7>
+  abort 'account file not specified.' unless ARGV.size == 1
+  app = AmazonManipulator.new(ARGV[0])
   app.run
 end


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/ASONE0923/amazon_manipulator/commit/46aa61de7d3e8687746ea64cf1dc6d95cb94906d

## やったこと

* 1.ログインの処理を、名前をつけて分けたメソッドの呼び出しで書き換えた。
* 2.ログアウトの処理を、名前をつけて分けたメソッドの呼び出しで書き換えた。
* 3.runメソッドは、loginとlogoutを使って表せるようになった。アプリケーションの処理時間の代わりにsleepを入れておいた。
* 4.クラスの外部で使うメソッドは、privateなメソッドにしておく。
* 5.wait.untilで要素の表示を持って、表示要素を取得するところを共通のメソッドにした。
* 6.AmazonのWebサイトのトップページを開く。
* 7.「アカウント&リスト」を探してクリックし、ログインページを開く。
* 8.ログインページで、メールアドレスの入力フィールドを探し、メールアドレスを入力して「次へ進む」をクリックする。
* 9.パスワードの入力ページで、パスワード入力フィールドを探し、パスワードを入力し「ログイン」をクリックする。
* 10.ログインが完了するのを待つ。
* 11.ログアウトのリンクがあるポップアップウィンドウを開く。
* 12.「ログアウト」をクリックしてログアウトし、再びログインページが開くのを待つ。


## やらないこと

* 無し

## できるようになること（ユーザ目線）

* 無し

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* 動作に問題なし。
* 「タイトル&リスト」のテキストを表示するのをやめたので、出力結果は何もなくなりました。

[![Image from Gyazo](https://i.gyazo.com/9c69f8d50af4cc60e990bc8bca4b71b2.png)](https://gyazo.com/9c69f8d50af4cc60e990bc8bca4b71b2)

## その他

* 無し